### PR TITLE
Added fixes from VCPKG discussion

### DIFF
--- a/ports/freetype/vcpkg-cmake-wrapper.cmake
+++ b/ports/freetype/vcpkg-cmake-wrapper.cmake
@@ -2,7 +2,60 @@ cmake_policy(PUSH)
 cmake_policy(SET CMP0012 NEW)
 cmake_policy(SET CMP0054 NEW)
 
-_find_package(${ARGS})
+# CMake comes with FindFreetype module which conflicts with Freetype 2.13.x's and onwards freetype-config.cmake
+# which now defines the same target. To fix this, we stop the FindFreetype.cmake module from running, and just
+# use the configs settings instead.
+list(REMOVE_ITEM ARGS NO_MODULE CONFIG MODULE)
+_find_package(${ARGS} NAMES freetype)
+
+if(NOT TARGET Freetype::Freetype)
+    message( FATAL_ERROR "The freetype vcpkg-cmake-wrapper.cmake assumes the existence of the"
+            "'Freetype::Freetype' target, which should be exposed in freetype-config.cmake through freetype-targets.cmake" )
+endif()
+if(NOT TARGET freetype)
+    message( FATAL_ERROR "The freetype vcpkg-cmake-wrapper.cmake assumes the existence of the"
+            "'freetype' target, which should be exposed in freetype-config.cmake through freetype-targets.cmake" )
+endif()
+# we need to make sure that targets that previously depended on the module definition of Freetype still have access
+# to the exposed result variables needed here:
+# https://cmake.org/cmake/help/latest/module/FindFreetype.html#result-variables
+# Those variables are:
+#     FREETYPE_FOUND
+#     FREETYPE_INCLUDE_DIRS
+#     Don't know if these need to actually be exposed, they are merely mentioned in the above link.
+#         FREETYPE_INCLUDE_DIR_ft2build
+#         FREETYPE_INCLUDE_DIR_freetype2
+#     FREETYPE_LIBRARIES
+#     FREETYPE_VERSION_STRING
+set(FREETYPE_FOUND TRUE)
+
+# Not trying to get LINK_LIBRARIES because only interface is exposed on the INTERFACE as of this update.  In future updates
+# we may need to add changes here as Freetype continually adds changes to it's CMake distribution strategy (22/01/2024)
+get_target_property(TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_LINK_LIBRARIES Freetype::Freetype INTERFACE_LINK_LIBRARIES)
+set(FREETYPE_LIBRARIES "")
+list(APPEND FREETYPE_LIBRARIES ${TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_LINK_LIBRARIES})
+unset(TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_LINK_LIBRARIES)
+
+
+
+# Not trying to get INCLUDE_DIRECTORIES because only INTERFACE is exposed on the target as of this update.  In future updates
+# we may need to add changes here as Freetype continually adds changes to it's CMake distribution strategy (22/01/2024)
+# Note for whatever reason we can't get the interface include directories from the Freetype::Freetype target...
+get_target_property(TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_INCLUDE_DIRECTORIES freetype INTERFACE_INCLUDE_DIRECTORIES)
+set(FREETYPE_INCLUDE_DIRS "")
+list(APPEND FREETYPE_INCLUDE_DIRS ${TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_INCLUDE_DIRECTORIES})
+
+# Don't think we need these targets exposed, but they are mentioned in https://cmake.org/cmake/help/latest/module/FindFreetype.html#result-variables
+# so exposing them anyway.  In practice INTERFACE_INCLUDE_DIRECTORIES ends up just being the base install include
+# directory, and FREETYPE_INCLUDE_DIR_ft2build and FREETYPE_INCLUDE_DIR_freetype2 end up being the same thing
+set(FREETYPE_INCLUDE_DIR_ft2build ${TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_INCLUDE_DIRECTORIES})
+set(FREETYPE_INCLUDE_DIR_freetype2 ${TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_INCLUDE_DIRECTORIES})
+unset(TEMP_VCPKG_FREETYPE_CONFIG_TARGET_INTERFACE_INCLUDE_DIRECTORIES)
+
+
+# Version is not set on Freetype::Freetype or freetype, we have to get it from this variable.
+set(FREETYPE_VERSION_STRING ${Freetype_VERSION})
+
 
 if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
     if("@FT_REQUIRE_ZLIB@")

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5616ab61c5468f3e8fa58ba7a4af92cf90a64c0e",
+      "git-tree": "50f5625e6f488a287b61c86e079eea667c5b4394",
       "version": "2.13.2",
       "port-version": 0
     },


### PR DESCRIPTION
added fixes from https://github.com/microsoft/vcpkg/pull/31382#discussion_r1193414743 removed MODULE from find_package args as outlined, then filled in the specified variables here: https://cmake.org/cmake/help/latest/module/FindFreetype.html#result-variables to the best of my abilities.  Currently FREETYPE_LIBRARIES is not exactly the same, in that it contains generator expressions and targets in addition to actual .lib files, don't know if this is an issue.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
